### PR TITLE
Add known deployments to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ $service->get("/swagger", function (Request $request, Response $response) {
 
 Travis CI is configured to run our build and deployment process on AWS.
 
+Deployments (AWS account `nypl-digital-dev`):
+ * Production: Lambda > Functions > JobService-production
+ * QA: Lambda > Functions > JobService-qa
+
 Our Travis CI/CD pipeline will execute the following steps for each deployment trigger:
 
 * Run unit test coverage


### PR DESCRIPTION
This PR just adds notes about where this app is deployed.

Marking it DRAFT because AWS Node runtimes have advanced considerably and the deploy will certainly fail, so any updates to this app (even documentation improvements) must accompany Node version updates and the addition of the lib-for-node10-wrapped-php7 lambda layer necessitated by Node 10 e.g. https://github.com/NYPL/refile-request-service/pull/38/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519